### PR TITLE
Fix apk permissions in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM returntocorp/semgrep:develop
 
+USER 0
 RUN apk add make
+USER 1000
 
 ADD entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
The Semgrep docker image now (rightly) runs with a non-root user, but
this means we need to switch back to root in order to install make.